### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -15,8 +15,7 @@ class ItemsController < ApplicationController
       redirect_to root_path
     else
       render :new
-    end 
-
+    end
   end
 
   def show

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: :index
+  before_action :authenticate_user!, except: [:index, :show]
 
   def index
     @items = Item.all.order('created_at DESC')
@@ -15,7 +15,12 @@ class ItemsController < ApplicationController
       redirect_to root_path
     else
       render :new
-    end
+    end 
+
+  end
+
+  def show
+    @item = Item.find(params[:id])
   end
 
   private

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -21,7 +21,6 @@ class Item < ApplicationRecord
     validates :image
   end
 
-
   with_options numericality: { other_than: 1 } do
     validates :category_id, :status_id, :shipping_charge_id, :prefecture_id, :estimated_shipping_date_id
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -21,6 +21,7 @@ class Item < ApplicationRecord
     validates :image
   end
 
+
   with_options numericality: { other_than: 1 } do
     validates :category_id, :status_id, :shipping_charge_id, :prefecture_id, :estimated_shipping_date_id
   end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,10 +129,10 @@
       
       <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to items_path do %>
+        <%= link_to items_path(item.id), method: :get do %>
         <div class='item-img-content'>
-          <%= image_tag item.image, class: "item-img" %>
-
+          <%= link_to image_tag(item.image, class: "item-img"), item_path(item) %>
+ 
           <%# 商品が売れていればsold outを表示しましょう %>
          <%# <div class='sold-out'>
             <span>Sold Out!!</span>
@@ -142,10 +142,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= item.name %>
+            <%=link_to item.name, item_path(item) %>
           </h3>
           <div class='item-price'>
-            <span><%= item.price %>円<br>(税込み)</span>
+            <span><%= link_to item.price, item_path(item) %>円<br>(税込み)</span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -42,7 +42,7 @@
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description  %></span>
     </div>
     <table class="detail-table">
       <tbody>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,33 +4,38 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
+
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class='sold-out'>
+      <%#<div class='sold-out'>
         <span>Sold Out!!</span>
       </div>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
+
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price %>
       </span>
       <span class="item-postage">
-        (税込) 送料込み
+        <% @item.shipping_charge_id %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
+     <% if user_signed_in? %>
+       <% if user_signed_in? && current_user.id == @item.user_id %>
+         <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+         <p class='or-text'>or</p>
+         <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+       <% elsif current_user.id %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+         <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+       <% end %>
+     <% end %>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
 
 
@@ -43,27 +48,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_charge.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name  %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.estimated_shipping_date.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -31,7 +31,7 @@
          <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
          <p class='or-text'>or</p>
          <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-       <% elsif current_user.id %>
+       <% elsif user_signed_in? && current_user.id != @item.user_id %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
          <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
        <% end %>
@@ -107,7 +107,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only:[:new, :create, :index] 
+  resources :items, only:[:new, :create, :index, :show] 
 end


### PR DESCRIPTION
＃What
商品詳細表示機能の作成
＃Why
商品詳細表示機能を実装するため

- ログアウト状態のユーザーでも、商品詳細表示ページを閲覧できること
- ログアウト状態のユーザーには、「編集・削除・購入画面に進むボタン」が表示されないこと
https://i.gyazo.com/0dbeb41c116645ea8c49031e1c12e70a.gif

- ログイン状態の出品者のみ、「編集・削除ボタン」が表示されること
- ログイン状態の出品者でも、売却済みの商品に対しては「編集・削除ボタン」が表示されないこと
- 商品出品時に登録した情報が見られるようになっていること
https://i.gyazo.com/9405c20fea257fc115ff9a7a98abf762.gif

- ログイン状態の出品者以外のユーザーのみ、「購入画面に進むボタン」が表示されること
https://i.gyazo.com/2f2cb13f79f1731ee6553135c259c9d6.gif
